### PR TITLE
fix mod path.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module iqtlabs/faucetconfrpc
+module github.com/iqtlabs/faucetconfrpc


### PR DESCRIPTION
go: github.com/iqtlabs/faucetconfrpc@v0.22.46: parsing go.mod:
	module declares its path as: iqtlabs/faucetconfrpc
	        but was required as: github.com/iqtlabs/faucetconfrpc