### PR TITLE
Fix release workflow guards after iqtlabs -> anarkiwi transfer

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,7 +32,7 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}
       run: |
         echo "${DOCKER_PASSWORD}" | docker login --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-      if: github.repository == 'iqtlabs/faucetconfrpc' && github.event_name == 'push'
+      if: github.repository == 'anarkiwi/faucetconfrpc' && github.event_name == 'push'
 
     - name: Build and push platforms
       env:
@@ -49,4 +49,4 @@ jobs:
           --platform linux/amd64,linux/arm64 \
           --push --no-cache \
           -t iqtlabs/faucet-certstrap:${{ steps.change_version.outputs.VERSION }} certstrap
-      if: github.repository == 'iqtlabs/faucetconfrpc' && github.event_name == 'push'
+      if: github.repository == 'anarkiwi/faucetconfrpc' && github.event_name == 'push'

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -22,4 +22,4 @@ jobs:
         sudo apt-get install -yq --no-install-recommends git python3 python3-dev && \
         poetry build && \
         poetry publish -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_TOKEN }}
-      if: github.repository == 'iqtlabs/faucetconfrpc' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      if: github.repository == 'anarkiwi/faucetconfrpc' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "faucetconfrpc"
-version = "0.55.81"
+version = "0.55.82"
 description = "utility to manage FAUCET config files via RPC"
 authors = ["Charlie Lewis <clewis@iqt.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
The repository was transferred from iqtlabs/faucetconfrpc to anarkiwi/faucetconfrpc, but the workflow conditionals in pypi.yaml and docker.yaml still check for the old `github.repository` slug and silently skip the publish steps. As a result the v0.55.80 and v0.55.81 tag pushes built nothing — PyPI is still at 0.55.79 and Docker Hub at v0.55.79.

This blocks downstream consumers like dovesnap from picking up cryptography 48.0.0 (which fixes CVE-2026-34073 and CVE-2026-39892) and other security updates already on main.

Update the guards to anarkiwi/faucetconfrpc and bump the version to 0.55.82 (0.55.81 was already consumed by a tag that did not publish; PyPI rejects re-uploads of an existing version, so a new version number is required).

After this merges, tagging v0.55.82 should publish to PyPI and Docker Hub. The Docker image push targets (iqtlabs/faucetconfrpc and iqtlabs/faucet-certstrap on Docker Hub) and the Go module path (github.com/iqtlabs/faucetconfrpc, which GitHub redirects) intentionally still reference the iqtlabs namespace so downstream consumers continue to resolve unchanged.