### PR TITLE
Attach release workflows to the release GitHub Environment

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,6 +9,7 @@ jobs:
   buildx:
 
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Install Poetry


### PR DESCRIPTION
## Summary
- Add `environment: release` to the publish job in `pypi.yaml` and the buildx job in `docker.yaml` so the environment-scoped secrets become reachable.
- Without this, the v0.55.82 tag-push release ran `poetry publish -u  -p ` and failed with `The "--username" option requires a value` (and buildx similarly failed at `docker login --username ""`).

## Background
- `PYPI_USERNAME` and `PYPI_TOKEN` were configured as **environment** secrets on the `release` GitHub Environment, not as repository secrets.
- GitHub only injects environment secrets when the job declares `environment:`. Neither workflow did, so the templated values were empty strings.
- PyPI is still at 0.55.79; Docker Hub `iqtlabs/faucetconfrpc` is also at v0.55.79. v0.55.80 / .81 / .82 all built nothing.

## Follow-ups after merge
- Force-move the `v0.55.82` tag onto the merge commit and re-run the release workflows (0.55.82 was never uploaded to PyPI, so the version number is reusable).
- Add `DOCKER_USERNAME` / `DOCKER_TOKEN` to the same `release` environment to unblock the buildx job — workflow side is now wired, secrets are still missing.

## Test plan
- [ ] After merge, force-move `v0.55.82` and confirm the `release` workflow run uploads `faucetconfrpc-0.55.82` to PyPI.
- [ ] Confirm buildx login error changes from "Must provide --username" (secret missing entirely) to a real auth attempt once Docker secrets are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)