### PR TITLE
Authenticate to PyPI as __token__

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -22,5 +22,5 @@ jobs:
         sudo apt-get update && \
         sudo apt-get install -yq --no-install-recommends git python3 python3-dev && \
         poetry build && \
-        poetry publish -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_TOKEN }}
+        poetry publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}
       if: github.repository == 'anarkiwi/faucetconfrpc' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')


### PR DESCRIPTION
## Summary
- Hardcode `-u __token__` in `pypi.yaml` so the publish step uses PyPI's API-token auth scheme. `PYPI_TOKEN` still provides the password.
- Drops the reference to `PYPI_USERNAME`, which can be deleted from the `release` GitHub Environment after this lands.

## Background
After PR #1040 fixed the environment wiring, the v0.55.82 release run reached the upload step (got to 100%) before PyPI returned:

> HTTP Error 403: Forbidden | Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead.

PyPI no longer accepts real username/password basic auth — when using an API token the username must be the literal string `__token__`. Making that a knob via `PYPI_USERNAME` just invites misconfiguration; the only valid value is `__token__`.

## Follow-ups after merge
- Force-move `v0.55.82` onto the merge commit again to retrigger the release workflow.
- Confirm `PYPI_TOKEN` in the `release` environment is a real PyPI API token (begins with `pypi-`). If it is a password, the next run will hit the same 403.
- Remove the now-unused `PYPI_USERNAME` env secret.

## Test plan
- [ ] After force-moving v0.55.82, the release run uploads faucetconfrpc 0.55.82 to PyPI.
- [ ] PyPI JSON reports 0.55.82 as the latest version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)