### PR TITLE
Republish as faucetconfrpc-ng 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An RPC server/client for Faucet YAML config files.
 
+> **Note:** this is the anarkiwi fork of `faucetconfrpc`. It is published to PyPI as **`faucetconfrpc-ng`** (`pip install faucetconfrpc-ng`) because the original `faucetconfrpc` PyPI project remains under previous ownership. The import path is unchanged — `import faucetconfrpc` works as before.
+
 ## Overview
 
 The Faucet SDN controller obtains its configuration from at least one YAML file,
@@ -47,7 +49,7 @@ $ docker build -f Dockerfile.server . -t iqtlabs/faucetconfrpc
 $ docker run -v /tmp/keydir:/keydir -v /tmp/conf_dir:/conf_dir -p 59999:59999/tcp iqtlabs/faucetconfrpc:latest --key=/keydir/localhost.key --cert=/keydir/localhost.crt --cacert=/keydir/ca.crt --host=0.0.0.0 --config_dir=/conf_dir
 ```
 
-In another terminal, having run `pip3 install faucetconfrpc`:
+In another terminal, having run `pip3 install faucetconfrpc-ng`:
 
 ```
 $ faucetconfrpc_client.py get_config_file --key=/tmp/keydir/client.key --cert=/tmp/keydir/client.crt --cacert=/tmp/keydir/ca.crt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [tool.poetry]
-name = "faucetconfrpc"
-version = "0.55.82"
-description = "utility to manage FAUCET config files via RPC"
+name = "faucetconfrpc-ng"
+version = "1.0.0"
+description = "utility to manage FAUCET config files via RPC (anarkiwi fork)"
 authors = ["Charlie Lewis <clewis@iqt.org>"]
 license = "Apache-2.0"
+packages = [{include = "faucetconfrpc", from = "src"}]
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"


### PR DESCRIPTION
## Summary
- Rename the PyPI **distribution** to `faucetconfrpc-ng` and reset the version to `1.0.0`.
- Keep the Python **import** path as `faucetconfrpc` — `src/faucetconfrpc/` is unchanged.
- Update README install snippet and add a fork notice.

## Background
After the workflow-side issues were fixed (PRs #1039, #1040, #1041), the v0.55.82 release run finally reached PyPI with valid credentials but was rejected:

> HTTP 403: The user 'anarkiwi' isn't allowed to upload to project 'faucetconfrpc'.

The `faucetconfrpc` PyPI project remains under previous ownership; the anarkiwi account cannot publish to that distribution name. Republishing under a new name is the cleanest unblock for downstream consumers waiting on the cryptography 48.0.0 / urllib3 2.7.0 / etc. updates already on `main`.

## Migration note for downstream consumers
- `pip install faucetconfrpc` → `pip install faucetconfrpc-ng`
- `import faucetconfrpc` — **no change**
- Docker image tags (`iqtlabs/faucetconfrpc:vX`) — separate concern, not affected here

## Notes on the change
- Because the distribution name no longer matches the package directory, we declare `packages = [{include="faucetconfrpc", from="src"}]` so Poetry finds the existing `src/faucetconfrpc/` directory instead of looking for `faucetconfrpc_ng/`.
- Build verified locally: produces `faucetconfrpc_ng-1.0.0-py3-none-any.whl` containing the unchanged `faucetconfrpc/` import package.

## Follow-ups after merge
- Tag `v1.0.0` on the merge commit. The release workflow will publish — since the `faucetconfrpc-ng` project does not exist on PyPI yet, the first upload from a user-scoped `PYPI_TOKEN` will create it and register `anarkiwi` as the owner. After the first publish, generate a project-scoped token and rotate `PYPI_TOKEN` to that.
- Delete the obsolete `v0.55.80`, `v0.55.81`, `v0.55.82` tags once `v1.0.0` is published (none of them resulted in a PyPI artifact).
- `PYPI_USERNAME` env secret is no longer referenced and can be removed.
- Docker publish (`iqtlabs/faucetconfrpc`) remains unconfigured — `DOCKER_USERNAME` / `DOCKER_TOKEN` still need to be added to the `release` environment, and the anarkiwi account needs push rights to the `iqtlabs/*` Docker Hub namespace (likely a similar permission wall to expect).

## Test plan
- [ ] After merge, tag `v1.0.0` and confirm the release workflow uploads `faucetconfrpc-ng 1.0.0` to PyPI.
- [ ] `pip install faucetconfrpc-ng` then `python -c "import faucetconfrpc"` succeeds in a clean venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)