### PR TITLE
Publish Docker images to the anarkiwi namespace

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,9 +45,9 @@ jobs:
           --platform linux/amd64,linux/arm64 \
           --push \
           --file Dockerfile.server \
-          -t iqtlabs/faucetconfrpc:${{ steps.change_version.outputs.VERSION }} . && \
+          -t anarkiwi/faucetconfrpc:${{ steps.change_version.outputs.VERSION }} . && \
         docker buildx build \
           --platform linux/amd64,linux/arm64 \
           --push --no-cache \
-          -t iqtlabs/faucet-certstrap:${{ steps.change_version.outputs.VERSION }} certstrap
+          -t anarkiwi/faucet-certstrap:${{ steps.change_version.outputs.VERSION }} certstrap
       if: github.repository == 'anarkiwi/faucetconfrpc' && github.event_name == 'push'

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ $ cat<<EOD>/tmp/conf_dir/faucet.yaml
        1:
           native_vlan: 100
 EOD
-$ docker build -f Dockerfile.server . -t iqtlabs/faucetconfrpc
-$ docker run -v /tmp/keydir:/keydir -v /tmp/conf_dir:/conf_dir -p 59999:59999/tcp iqtlabs/faucetconfrpc:latest --key=/keydir/localhost.key --cert=/keydir/localhost.crt --cacert=/keydir/ca.crt --host=0.0.0.0 --config_dir=/conf_dir
+$ docker build -f Dockerfile.server . -t anarkiwi/faucetconfrpc
+$ docker run -v /tmp/keydir:/keydir -v /tmp/conf_dir:/conf_dir -p 59999:59999/tcp anarkiwi/faucetconfrpc:latest --key=/keydir/localhost.key --cert=/keydir/localhost.crt --cacert=/keydir/ca.crt --host=0.0.0.0 --config_dir=/conf_dir
 ```
 
 In another terminal, having run `pip3 install faucetconfrpc-ng`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "faucetconfrpc-ng"
-version = "1.0.0"
+version = "1.0.1"
 description = "utility to manage FAUCET config files via RPC (anarkiwi fork)"
 authors = ["Charlie Lewis <clewis@iqt.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Push Docker images to `anarkiwi/faucetconfrpc` and `anarkiwi/faucet-certstrap` instead of the `iqtlabs/*` namespace.
- Update README docker examples to match.
- Bump pyproject to `1.0.1` so re-tagging triggers a clean rebuild without colliding with the already-published `faucetconfrpc-ng 1.0.0` on PyPI.

## Background
With `DOCKER_USERNAME` / `DOCKER_TOKEN` now in the `release` GitHub Environment, the v1.0.0 buildx run actually logged in successfully — but it was about to push to `iqtlabs/*`, which anarkiwi shouldn't be publishing under. That run was cancelled.

This is the parallel of the PyPI pivot in #1042: anarkiwi controls the `anarkiwi/*` Docker Hub namespace, not `iqtlabs/*`.

## Migration note for downstream consumers
- `docker pull iqtlabs/faucetconfrpc:vX` → `docker pull anarkiwi/faucetconfrpc:vX`
- `docker pull iqtlabs/faucet-certstrap:vX` → `docker pull anarkiwi/faucet-certstrap:vX`
- Image content is unchanged.

## Why 1.0.1 and not a force-moved 1.0.0
- The v1.0.0 tag's `release` job already published `faucetconfrpc-ng 1.0.0` to PyPI.
- Force-moving v1.0.0 would re-run the release workflow, which would fail because PyPI rejects re-uploads.
- Bumping to 1.0.1 lets both `release` and `buildx` jobs complete cleanly on the new tag.

## Follow-ups after merge
- Tag `v1.0.1` and confirm both jobs succeed.
- Confirm Docker Hub `anarkiwi/faucetconfrpc:v1.0.1` and `anarkiwi/faucet-certstrap:v1.0.1` exist; the `latest` tag is produced by pushes to `main`.

## Test plan
- [ ] After merge + tag, `gh run view` shows both `release` and `buildx` succeed for v1.0.1.
- [ ] `docker pull anarkiwi/faucetconfrpc:v1.0.1` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)