### PR TITLE
Dedupe test workflow triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   docker-test:


### PR DESCRIPTION
## Summary

Switch `on: [push, pull_request]` → `push: branches: [main]` + `pull_request` in `test.yml`, so PR commits don't fire both `push` and `pull_request` runs of the same SHA. Halves the number of test runs (and failure notifications) on Dependabot/Renovate PRs.

## Test plan

- [ ] Only one `test` run is created per PR commit, not two.